### PR TITLE
Refactor mock generation config to use mockStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - **Automatic Reference Resolution:** Handles `$ref` and schema composition, so your builders reflect your OpenAPI definitions accurately.
 - **Seamless Integration:** Designed to work with Hey API's plugin system and TypeScript type generation.
 - **Zero External Dependencies:** No need for faker.js or other heavy dependencies - the custom runtime is lightweight and fast.
-- **Configurable Output:** Choose between custom runtime, Zod, or static mock generation.
+- **Flexible Configuration:** Choose between custom runtime, Zod, or static mock generation using a simple `mockStrategy` option.
 
 ## Installation
 
@@ -56,16 +56,31 @@ export default defineConfig({
     defineBuildersConfig({
       // Optional: Generate Zod schemas for validation
       generateZod: true,
-      // Optional: Use Zod for mock generation (requires zod-mock library)
-      useZodForMocks: false,
-      // Optional: Use static mock generation (no runtime dependencies)
-      useStaticMocks: false,
+      // Optional: Mock generation strategy (default: 'runtime')
+      // Options: 'runtime' | 'zod' | 'static'
+      mockStrategy: 'runtime',
       // Optional: Custom output filename
       output: 'builders.gen.ts'
     }),
   ],
 });
 ```
+
+### Configuration Options
+
+- **generateZod** (boolean): Generate Zod schemas alongside builders for validation. Default: `false`.
+- **mockStrategy** (string): Strategy for generating mock data. Default: `'runtime'`.
+  - `'runtime'`: Use custom lightweight runtime mock generation
+  - `'zod'`: Use Zod for mock generation
+  - `'static'`: Generate static mock builders without runtime dependencies
+- **output** (string): Output filename (without extension) for the generated builders. Default: `'builders'`.
+
+### Deprecated Options
+
+The following options are deprecated but still supported for backward compatibility:
+
+- **useZodForMocks** (boolean): Use `mockStrategy: 'zod'` instead.
+- **useStaticMocks** (boolean): Use `mockStrategy: 'static'` instead.
 
 ## Usage
 
@@ -99,13 +114,6 @@ if (result.success) {
 }
 ```
 
-## Configuration Options
-
-- **generateZod** (boolean): Generate Zod schemas alongside builders for validation. Default: `false`.
-- **useZodForMocks** (boolean): Use Zod for mock generation instead of the custom runtime. Default: `false`.
-- **useStaticMocks** (boolean): Generate static mock builders without runtime dependencies. When enabled, generates hardcoded mock values based on schema types. Default: `false`.
-- **output** (string): Output filename (without extension) for the generated builders. Default: `'builders'`.
-
 ## Mock Generation Strategies
 
 ### Custom Runtime (Default)
@@ -113,6 +121,12 @@ if (result.success) {
 The default strategy uses a lightweight custom mock generator that supports all JSON Schema features without external dependencies. This provides fast, predictable mock data generation.
 
 ```typescript
+// Configuration
+defineBuildersConfig({
+  mockStrategy: 'runtime', // or omit for default
+})
+
+// Usage
 import { UserBuilder } from './client/builders';
 
 const user = new UserBuilder()
@@ -129,7 +143,7 @@ Features:
 
 ### Static Mocks
 
-When `useStaticMocks: true` is enabled, the plugin generates hardcoded mock values directly in the builder classes. This approach:
+When `mockStrategy: 'static'` is configured, the plugin generates hardcoded mock values directly in the builder classes. This approach:
 
 - **No runtime generation** - All values are pre-computed at build time
 - **Predictable values** - generates consistent, type-appropriate default values
@@ -139,7 +153,7 @@ When `useStaticMocks: true` is enabled, the plugin generates hardcoded mock valu
 ```typescript
 // Configuration
 defineBuildersConfig({
-  useStaticMocks: true,
+  mockStrategy: 'static',
 })
 
 // Usage - same API, but mocks are statically generated
@@ -159,7 +173,19 @@ Static mocks generate appropriate defaults based on OpenAPI types and formats:
 
 ### Zod Integration
 
-When `useZodForMocks: true` is enabled, mock generation uses Zod schemas. This is experimental and provides runtime validation.
+When `mockStrategy: 'zod'` is configured, mock generation uses Zod schemas. This is experimental and provides runtime validation.
+
+```typescript
+// Configuration
+defineBuildersConfig({
+  mockStrategy: 'zod',
+})
+
+// Usage
+const user = new UserBuilder()
+  .withName('Alice')
+  .build(); // Uses Zod for mock generation
+```
 
 ## Format Support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hey-api-builders",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "description": "A custom plugin for @hey-api/openapi-ts that generates mock data builders with a lightweight custom runtime, Zod integration, or static mock generation.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/code-generator.test.ts
+++ b/src/core/code-generator.test.ts
@@ -78,10 +78,9 @@ describe('Code Generator', () => {
   });
 
   describe('generateImports', () => {
-    it('generates JSF imports when useStaticMocks is false', () => {
+    it('generates runtime imports when mockStrategy is runtime', () => {
       const result = generateImports({
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
         generateZod: false,
       });
 
@@ -91,10 +90,9 @@ describe('Code Generator', () => {
       expect(result).not.toContain('import { z }');
     });
 
-    it('generates Zod imports when useZodForMocks is true', () => {
+    it('generates Zod imports when mockStrategy is zod', () => {
       const result = generateImports({
-        useStaticMocks: false,
-        useZodForMocks: true,
+        mockStrategy: 'zod',
         generateZod: false,
       });
 
@@ -103,10 +101,9 @@ describe('Code Generator', () => {
       expect(result).not.toContain('import { generateMock }');
     });
 
-    it('generates no library imports when useStaticMocks is true', () => {
+    it('generates no library imports when mockStrategy is static', () => {
       const result = generateImports({
-        useStaticMocks: true,
-        useZodForMocks: false,
+        mockStrategy: 'static',
         generateZod: false,
       });
 
@@ -117,8 +114,7 @@ describe('Code Generator', () => {
 
     it('includes Zod import when generateZod is true', () => {
       const result = generateImports({
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
         generateZod: true,
       });
 
@@ -127,8 +123,7 @@ describe('Code Generator', () => {
 
     it('includes Zod import only once when both options use it', () => {
       const result = generateImports({
-        useStaticMocks: false,
-        useZodForMocks: true,
+        mockStrategy: 'zod',
         generateZod: true,
       });
 
@@ -212,8 +207,7 @@ describe('Code Generator', () => {
   describe('generateImports edge cases', () => {
     it('includes all imports when all options are enabled', () => {
       const result = generateImports({
-        useStaticMocks: false,
-        useZodForMocks: true,
+        mockStrategy: 'zod',
         generateZod: true,
       });
 
@@ -224,8 +218,7 @@ describe('Code Generator', () => {
 
     it('includes only base imports when no options are enabled', () => {
       const result = generateImports({
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
         generateZod: false,
       });
 
@@ -235,8 +228,7 @@ describe('Code Generator', () => {
 
     it('handles static mocks correctly', () => {
       const result = generateImports({
-        useStaticMocks: true,
-        useZodForMocks: false,
+        mockStrategy: 'static',
         generateZod: false,
       });
 

--- a/src/core/code-generator.ts
+++ b/src/core/code-generator.ts
@@ -1,4 +1,4 @@
-import type { Schema } from '../types';
+import type { Schema, MockStrategy } from '../types';
 import type { ExtendedSchema } from '../types';
 import { toPascal } from './string-utils';
 
@@ -31,20 +31,19 @@ export function generateWithMethods(schema: Schema, typeName: string): string {
  * @returns Import statements
  */
 export function generateImports(options: {
-  useStaticMocks: boolean;
-  useZodForMocks: boolean;
+  mockStrategy: MockStrategy;
   generateZod: boolean;
 }): string {
-  const { useStaticMocks, useZodForMocks, generateZod } = options;
+  const { mockStrategy, generateZod } = options;
   let imports = '';
 
-  const needsZodImport = generateZod || useZodForMocks;
+  const needsZodImport = generateZod || mockStrategy === 'zod';
 
-  if (useStaticMocks) {
+  if (mockStrategy === 'static') {
     return 'import type * as types from "./types.gen"\n\n';
   }
 
-  if (useZodForMocks) {
+  if (mockStrategy === 'zod') {
     imports += 'import { generateMockFromZodSchema } from "hey-api-builders"\n';
   } else {
     imports += 'import { generateMock } from "hey-api-builders"\n';

--- a/src/generators/builder-generator.test.ts
+++ b/src/generators/builder-generator.test.ts
@@ -15,8 +15,7 @@ describe('Builder Generator', () => {
 
     it('generates basic enum builder structure', () => {
       const result = generateEnumBuilder(enumMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('export class StatusBuilder');
@@ -27,8 +26,7 @@ describe('Builder Generator', () => {
 
     it('generates custom runtime build method by default', () => {
       const result = generateEnumBuilder(enumMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('generateMock');
@@ -37,10 +35,9 @@ describe('Builder Generator', () => {
       expect(result).toContain('useExamples');
     });
 
-    it('generates static mock build method when useStaticMocks is true', () => {
+    it('generates static mock build method when mockStrategy is static', () => {
       const result = generateEnumBuilder(enumMeta, {
-        useStaticMocks: true,
-        useZodForMocks: false,
+        mockStrategy: 'static',
       });
 
       expect(result).not.toContain('generateMock');
@@ -48,10 +45,9 @@ describe('Builder Generator', () => {
       expect(result).toContain('as types.Status');
     });
 
-    it('generates Zod build method when useZodForMocks is true', () => {
+    it('generates Zod build method when mockStrategy is zod', () => {
       const result = generateEnumBuilder(enumMeta, {
-        useStaticMocks: false,
-        useZodForMocks: true,
+        mockStrategy: 'zod',
       });
 
       expect(result).toContain('generateMockFromZodSchema');
@@ -62,8 +58,7 @@ describe('Builder Generator', () => {
 
     it('includes all builder option properties', () => {
       const result = generateEnumBuilder(enumMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('useDefault');
@@ -93,8 +88,7 @@ describe('Builder Generator', () => {
 
     it('generates basic object builder structure', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('export class UserBuilder');
@@ -105,8 +99,7 @@ describe('Builder Generator', () => {
 
     it('generates with methods for properties', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('withName');
@@ -114,10 +107,9 @@ describe('Builder Generator', () => {
       expect(result).toContain('withAge');
     });
 
-    it('generates JSF build method with override merging', () => {
+    it('generates runtime build method with override merging', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('const mock = generateMock');
@@ -126,10 +118,9 @@ describe('Builder Generator', () => {
       expect(result).toContain('return mock');
     });
 
-    it('generates static mock build method when useStaticMocks is true', () => {
+    it('generates static mock build method when mockStrategy is static', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: true,
-        useZodForMocks: false,
+        mockStrategy: 'static',
       });
 
       expect(result).toContain('const baseMock =');
@@ -137,10 +128,9 @@ describe('Builder Generator', () => {
       expect(result).not.toContain('generateMock');
     });
 
-    it('generates Zod build method when useZodForMocks is true', () => {
+    it('generates Zod build method when mockStrategy is zod', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: true,
+        mockStrategy: 'zod',
       });
 
       expect(result).toContain('generateMockFromZodSchema');
@@ -158,8 +148,7 @@ describe('Builder Generator', () => {
       };
 
       const result = generateObjectBuilder(emptyMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('export class EmptyBuilder');
@@ -168,8 +157,7 @@ describe('Builder Generator', () => {
 
     it('preserves type safety in generated code', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('types.User');
@@ -179,8 +167,7 @@ describe('Builder Generator', () => {
 
     it('includes setOptions method', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('setOptions(o: BuilderOptions): this');
@@ -188,10 +175,9 @@ describe('Builder Generator', () => {
       expect(result).toContain('return this');
     });
 
-    it('uses correct schema reference in JSF mode', () => {
+    it('uses correct schema reference in runtime mode', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('schemas.UserSchema');
@@ -199,8 +185,7 @@ describe('Builder Generator', () => {
 
     it('generates type-safe override assignment', () => {
       const result = generateObjectBuilder(objectMeta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+        mockStrategy: 'runtime',
       });
 
       expect(result).toContain('const typedMock = mock as Record<string, unknown>');
@@ -219,14 +204,12 @@ describe('Builder Generator', () => {
         isObject: true,
       };
 
-      const jsfResult = generateObjectBuilder(meta, {
-        useStaticMocks: false,
-        useZodForMocks: false,
+      const runtimeResult = generateObjectBuilder(meta, {
+        mockStrategy: 'runtime',
       });
 
       const zodResult = generateObjectBuilder(meta, {
-        useStaticMocks: false,
-        useZodForMocks: true,
+        mockStrategy: 'zod',
       });
 
       const options = [
@@ -238,7 +221,7 @@ describe('Builder Generator', () => {
       ];
 
       options.forEach((option) => {
-        expect(jsfResult).toContain(option);
+        expect(runtimeResult).toContain(option);
         expect(zodResult).toContain(option);
       });
     });

--- a/src/generators/builder-generator.ts
+++ b/src/generators/builder-generator.ts
@@ -1,4 +1,4 @@
-import type { GeneratedSchemaMeta } from '../types';
+import type { GeneratedSchemaMeta, MockStrategy } from '../types';
 import type { Schema } from '../types';
 import { generateZodSchema } from './zod-schema-generator';
 import { generateStaticMockCode } from './static-mock-generator';
@@ -9,8 +9,7 @@ import { generateWithMethods } from '../core/code-generator';
  */
 
 export interface BuilderGeneratorOptions {
-  useStaticMocks: boolean;
-  useZodForMocks: boolean;
+  mockStrategy: MockStrategy;
 }
 
 /**
@@ -21,15 +20,15 @@ export function generateEnumBuilder(
   options: BuilderGeneratorOptions
 ): string {
   const { typeName, schema } = meta;
-  const { useStaticMocks, useZodForMocks } = options;
+  const { mockStrategy } = options;
 
   let code = `export class ${typeName}Builder {\n`;
   code += `  private options: BuilderOptions = {}\n`;
   code += `  setOptions(o: BuilderOptions): this { this.options = o || {}; return this }\n\n`;
 
-  if (useStaticMocks) {
+  if (mockStrategy === 'static') {
     code += generateStaticEnumBuild(typeName, schema);
-  } else if (useZodForMocks) {
+  } else if (mockStrategy === 'zod') {
     code += generateZodEnumBuild(typeName, schema);
   } else {
     code += generateCustomEnumBuild(typeName, meta.constName);
@@ -47,7 +46,7 @@ export function generateObjectBuilder(
   options: BuilderGeneratorOptions
 ): string {
   const { typeName, schema, constName } = meta;
-  const { useStaticMocks, useZodForMocks } = options;
+  const { mockStrategy } = options;
 
   let code = `export class ${typeName}Builder {\n`;
   code += `  private overrides: Partial<types.${typeName}> = {}\n`;
@@ -61,9 +60,9 @@ export function generateObjectBuilder(
 
   code += '\n';
 
-  if (useStaticMocks) {
+  if (mockStrategy === 'static') {
     code += generateStaticObjectBuild(typeName, schema);
-  } else if (useZodForMocks) {
+  } else if (mockStrategy === 'zod') {
     code += generateZodObjectBuild(typeName, schema);
   } else {
     code += generateCustomObjectBuild(typeName, constName);

--- a/src/plugin/config.test.ts
+++ b/src/plugin/config.test.ts
@@ -28,14 +28,21 @@ describe('config', () => {
     it('should return config with custom options', () => {
       const config = defineConfig({
         generateZod: true,
-        useStaticMocks: true,
+        mockStrategy: 'static',
       });
       expect(config).toBeDefined();
     });
 
-    it('should return config with useZodForMocks option', () => {
+    it('should return config with mockStrategy zod', () => {
       const config = defineConfig({
-        useZodForMocks: true,
+        mockStrategy: 'zod',
+      });
+      expect(config).toBeDefined();
+    });
+
+    it('should return config with mockStrategy runtime', () => {
+      const config = defineConfig({
+        mockStrategy: 'runtime',
       });
       expect(config).toBeDefined();
     });
@@ -46,6 +53,14 @@ describe('config', () => {
     });
 
     it('should return config with all options', () => {
+      const config = defineConfig({
+        generateZod: true,
+        mockStrategy: 'zod',
+      });
+      expect(config).toBeDefined();
+    });
+
+    it('should support backward compatibility with deprecated flags', () => {
       const config = defineConfig({
         generateZod: true,
         useZodForMocks: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,11 @@ export interface Schema {
 }
 
 /**
+ * Mock generation strategy
+ */
+export type MockStrategy = 'runtime' | 'zod' | 'static';
+
+/**
  * Plugin configuration options
  */
 export interface Config {
@@ -75,12 +80,23 @@ export interface Config {
    */
   generateZod?: boolean;
   /**
+   * Strategy for generating mock data in builders
+   * - 'runtime': Use custom lightweight runtime mock generation (default)
+   * - 'zod': Use Zod schemas for mock generation
+   * - 'static': Generate hardcoded static mock values
+   *
+   * @default 'runtime'
+   */
+  mockStrategy?: MockStrategy;
+  /**
+   * @deprecated Use mockStrategy: 'zod' instead
    * Use Zod for mock generation instead of JSON Schema Faker
    *
    * @default false
    */
   useZodForMocks?: boolean;
   /**
+   * @deprecated Use mockStrategy: 'static' instead
    * Generate static mock builders without runtime dependencies
    * When enabled, generates hardcoded mock values based on schema types
    * instead of using JSON Schema Faker or Zod at runtime

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,6 +2,8 @@ import {DefinePlugin} from "@hey-api/openapi-ts";
 import type { IR } from '@hey-api/openapi-ts';
 import type { Schema } from 'json-schema-faker';
 
+export type MockStrategy = 'runtime' | 'zod' | 'static';
+
 export interface Config {
     /**
      * Plugin name. Must be unique.
@@ -26,12 +28,23 @@ export interface Config {
      */
     generateZod?: boolean;
     /**
+     * Strategy for generating mock data in builders
+     * - 'runtime': Use custom lightweight runtime mock generation (default)
+     * - 'zod': Use Zod schemas for mock generation
+     * - 'static': Generate hardcoded static mock values
+     *
+     * @default 'runtime'
+     */
+    mockStrategy?: MockStrategy;
+    /**
+     * @deprecated Use mockStrategy: 'zod' instead
      * Use Zod for mock generation instead of JSON Schema Faker
      *
      * @default false
      */
     useZodForMocks?: boolean;
     /**
+     * @deprecated Use mockStrategy: 'static' instead
      * Generate static mock builders without runtime dependencies
      * When enabled, generates hardcoded mock values based on schema types
      * instead of using JSON Schema Faker or Zod at runtime


### PR DESCRIPTION
Replaces deprecated useZodForMocks and useStaticMocks flags with a unified mockStrategy option for configuring mock data generation. Updates all relevant code, tests, and documentation to support 'runtime', 'zod', and 'static' strategies, while maintaining backward compatibility with the old flags.