### PR TITLE
fix: publish tarball as local file

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Verify package metadata
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          TARBALL: release/${{ needs.prepare.outputs.filename }}
+          TARBALL: ./release/${{ needs.prepare.outputs.filename }}
         run: |
           test -f "$TARBALL"
           SPEC="$(
@@ -89,5 +89,5 @@ jobs:
       - name: Publish
         if: steps.registry.outputs.exists != 'true'
         env:
-          TARBALL: release/${{ needs.prepare.outputs.filename }}
+          TARBALL: ./release/${{ needs.prepare.outputs.filename }}
         run: npm publish "$TARBALL" --access public --ignore-scripts


### PR DESCRIPTION
npm interprets a bare release/package.tgz argument as GitHub shorthand. Prefix the verified tarball path with ./ so npm publishes the downloaded local artifact.

Validation:
- exact npm publish ./release/hey-api-builders-2.0.0.tgz --dry-run succeeds
- pnpm validate
- git diff --check